### PR TITLE
Added coffeescript fat arrow versions

### DIFF
--- a/snippets/meteor.cson
+++ b/snippets/meteor.cson
@@ -81,6 +81,12 @@
       Meteor.publish "${1:name}", (${2:argument}) ->
         ${3}
     """,
+  'Meteor Publish (fat)':
+    "prefix": "mmpub"
+    "body": """
+      Meteor.publish "${1:name}", (${2:argument}) =>
+        ${3}
+    """,
   'Meteor Subscribe':
     "prefix": "msub"
     "body": """
@@ -92,11 +98,24 @@
       Template.${1:name}.rendered ->
         ${2}
     """,
+  'Template Rendered (fat)':
+    "prefix": "mmren"
+    "body": """
+      Template.${1:name}.rendered =>
+        ${2}
+    """,
   'Template Helpers':
     "prefix": "mhel"
     "body": """
       Template.${1:name}.helpers
         ${2:helper}: ->
+          ${3}
+    """,
+  'Template Helpers (fat)':
+    "prefix": "mmhel"
+    "body": """
+      Template.${1:name}.helpers
+        ${2:helper}: =>
           ${3}
     """,
   'Template Events':
@@ -106,9 +125,22 @@
         "${2:event}": (e, t) ->
           ${3}
     """,
+  'Template Events (fat)':
+    "prefix": "mmevn"
+    "body": """
+      Template.${1:name}.events
+        "${2:event}": (e, t) =>
+          ${3}
+    """,
   'Template Created':
     "prefix": "mcre"
     "body": """
       Template.${1:name}.created ->
         ${2}
     """,
+  'Template Created (fat)':
+    "prefix": "mmcre"
+    "body": """
+      Template.${1:name}.created =>
+        ${2}
+    """


### PR DESCRIPTION
Just repeat the first letter of the normal prefix to preserve the scope.
